### PR TITLE
loading survey and country data

### DIFF
--- a/R/contact_matrix.r
+++ b/R/contact_matrix.r
@@ -263,6 +263,10 @@ contact_matrix <- function(survey, countries=c(), survey.pop, age.limits, filter
                 ## get population data for countries from 'wpp' package
                 country.pop <- data.table(wpp_age(survey.countries))
 
+                # !! warning: spelling can differ between wpp_age and wpp_countries (e.g. Viet Nam vs Vietnam) 
+                # fix: rename countries using the same approach as in clean(survey,...)
+                country.pop$country <- suppressWarnings(countrycode(country.pop$country, "country.name", "country.name"))
+                
                 ## check if survey data are from a specific year - in that case
                 ## use demographic data from that year, otherwise latest
                 if (columns[["year"]] %in% colnames(survey$participants))

--- a/R/contact_matrix.r
+++ b/R/contact_matrix.r
@@ -225,6 +225,21 @@ contact_matrix <- function(survey, countries=c(), survey.pop, age.limits, filter
         survey$participants <- survey$participants[!(get(columns[["id"]]) %in% missing.age.id)]
     }
 
+    # add an age group to each participant + modify age.breaks if age groups are not present
+    # note: use the adapted part.age.group.breaks afterwards for the survey.pop and contact data
+    survey$participants[, lower.age.limit := reduce_agegroups(get(columns[["participant.age"]]),
+                                                              age.limits[age.limits < max.age])]
+    part.age.group.breaks <- c(age.limits[age.limits < max.age], max.age)
+    survey$participants[, age.group :=
+                            cut(survey$participants[, get(columns[["participant.age"]])],
+                                breaks = part.age.group.breaks,
+                                right = FALSE)]
+    age.groups <- survey$participants[, levels(age.group)]
+    age.groups[length(age.groups)] <-
+        paste0(max(survey$participants$lower.age.limit, na.rm=TRUE), "+")
+    survey$participants[, age.group :=
+                            factor(age.group, levels=levels(age.group), labels=age.groups)]
+    
     ## if split or symmetric requested, get demographic data (survey population)
     need.survey.pop <- split || symmetric
     if (need.survey.pop)
@@ -314,43 +329,19 @@ contact_matrix <- function(survey, countries=c(), survey.pop, age.limits, filter
         }
         ## adjust age groups by interpolating, in case they don't match between
         ## demographic and survey data
-        survey.pop <- data.table(pop_age(survey.pop, age.limits, ...))
+        survey.pop <- data.table(pop_age(survey.pop, part.age.group.breaks, ...))
 
         ## possibly adjust age groups according to maximum age (so as not to have empty age groups)
-        survey.pop[, lower.age.limit := reduce_agegroups(lower.age.limit, age.limits)]
+        survey.pop[, lower.age.limit := reduce_agegroups(lower.age.limit, part.age.group.breaks)]
         survey.pop <- survey.pop[, list(population = sum(population)), by=lower.age.limit]
         setkey(survey.pop, lower.age.limit)
-        ## re-assign lower age limits in participants
-        survey$participants[, lower.age.limit :=
-                                  reduce_agegroups(get(columns[["participant.age"]]),
-                                                   survey.pop$lower.age.limit)]
-        present.lower.age.limits <- unique(survey.pop$lower.age.limit)
-        present.lower.age.limits <-
-            present.lower.age.limits[order(present.lower.age.limits)]
-
-        ## set upper age limits
-        survey.pop[, upper.age.limit := c(survey.pop$lower.age.limit[-1], max.age)]
-
-        lower.upper.age.limits <-
-            data.table(lower.age.limit = present.lower.age.limits,
-                       upper.age.limit = c(present.lower.age.limits[-1], max.age))
-        ## set upper age limits and construct age groups
-        survey$participants <-
-            merge(survey$participants, lower.upper.age.limits, by="lower.age.limit", all.x=TRUE)
-    }
-
-    survey$participants[, lower.age.limit := reduce_agegroups(get(columns[["participant.age"]]),
-                                                              age.limits[age.limits < max.age])]
-    part.age.group.breaks <- c(age.limits[age.limits < max.age], max.age)
-    survey$participants[, age.group :=
-                              cut(survey$participants[, get(columns[["participant.age"]])],
-                                  breaks = part.age.group.breaks,
-                                  right = FALSE)]
-    age.groups <- survey$participants[, levels(age.group)]
-    age.groups[length(age.groups)] <-
-        paste0(max(survey$participants$lower.age.limit, na.rm=TRUE), "+")
-    survey$participants[, age.group :=
-                              factor(age.group, levels=levels(age.group), labels=age.groups)]
+        
+        # remove age categories that are not present in the participant population (i.e. the last opend ended category)
+        survey.pop <- survey.pop[survey.pop$lower.age.limit %in% unique(survey$participants$lower.age.limit),]
+        
+        # set proportions
+        survey.pop[, proportion := survey.pop$population/sum(survey.pop$population)]
+        
 
     survey$participants[, weight := 1]
     survey$contacts[, weight := 1]

--- a/R/get_survey.r
+++ b/R/get_survey.r
@@ -35,7 +35,7 @@ get_survey <- function(survey, quiet=FALSE, ...)
         if (is.character(survey))
         {
             if (length(survey) > 1)
-                stop("if 'survey' is a DOI or URL, it must be of length 1")
+                warning("if 'survey' is a DOI or URL, it must be of length 1")
 
             survey <- sub("^(https?:\\/\\/(dx\\.)?doi\\.org\\/|doi:)", "", survey)
             survey <- sub("#.*$", "", survey)


### PR DESCRIPTION
If the input parameter of 'get_survey' was not a single DOI or URL, the function stopped, which prevented loading survey data from local files. So, changed "stop" into a "warning". 

Made the selection of country-specific reference data more robust: the spelling of country names differs between wpp_age and wpp_countries functions (eg. Vietnam vs Viet Nam), which caused a fatal error.