### PR TITLE
Update limits_to_agegroups.r

### DIFF
--- a/R/limits_to_agegroups.r
+++ b/R/limits_to_agegroups.r
@@ -10,18 +10,17 @@
 limits_to_agegroups <- function(x, limits) {
     if (missing(limits)) limits <- unique(x)[order(unique(x))]
     limits <- limits[!is.na(limits)]
-    agegroups <- c()
-    if (length(limits) > 1) {
-        agegroups <- vapply(seq(1, length(limits) - 1), function(y) {
+    agegroups <- if (length(limits) > 1) {
+        vapply(seq(1, length(limits) - 1), function(y) {
             if ((limits[y+1] - 1) > limits[y]) {
                 paste(limits[y], limits[y+1] - 1, sep = "-")
             } else {
                 paste(limits[y])
             }
         }, "")
-    }
+    } else { c() }
     agegroups <- c(agegroups, paste(limits[length(limits)], "+", sep = ""))
-    agegroups <- factor(agegroups, levels = agegroups)
+    agegroups <- factor(agegroups, levels = agegroups, ordered = TRUE)
     names(agegroups) <- limits
     return(unname(agegroups[as.character(x)]))
 }

--- a/tests/testthat/test-agegroups.r
+++ b/tests/testthat/test-agegroups.r
@@ -11,6 +11,16 @@ test_that("age groups can be created and manipulated",
   pop.age <- wpp_age("Germany", 2015)
 })
 
+test_that("age groups are ordered factors",
+{
+  ages <- seq_len(50)
+  age_limits <- c(0, 5, 10)
+  groups <- reduce_agegroups(ages, age_limits)
+  age_groups <- limits_to_agegroups(groups)
+  thing <- factor(c("a","b"), ordered = TRUE)
+  expect_length(setdiff(class(thing),class(age_groups)), 0)
+})
+
 test_that("pop_age throws warnings/errors",
 {
   expect_error(pop_age(3), "to be a data.frame")


### PR DESCRIPTION
allow returning ordered factors; defaults to `ordered=F`, which is consistent with current behavior